### PR TITLE
fix: use the correct key for plugin installation in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the plugin to your `opencode.json[c]`:
 
 ```json
 {
-  "plugins": [
+  "plugin": [
     "opencode-todo-reminder", ...//otherPlugins
   ]
 }


### PR DESCRIPTION
Hey, thanks for making this, super useful!

The configuration key for installing plugins should be `plugin` (singular), not `plugins`. The current README instructions doesn't work because of this typo.

See [opencode.ai/config.json](https://opencode.ai/config.json) for reference.