### PR TITLE
fix: todo-reminder 4-commit series — error-pause, in-progress wording, todowrite guard, orphan detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
     "name": "opencode-todo-reminder",
-    "version": "0.0.1",
+    "version": "0.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-todo-reminder",
-            "version": "0.0.1",
+            "version": "0.0.6",
+            "dependencies": {
+                "@opencode-ai/plugin": "^1.1.6"
+            },
             "devDependencies": {
-                "@opencode-ai/plugin": "^1.1.6",
                 "@opencode-ai/sdk": "^1.1.6",
                 "@types/node": "^22.0.0",
                 "typescript": "^5.9.3",
@@ -469,7 +471,6 @@
         },
         "node_modules/@opencode-ai/plugin": {
             "version": "1.1.6",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@opencode-ai/sdk": "1.1.6",
@@ -478,7 +479,6 @@
         },
         "node_modules/@opencode-ai/sdk": {
             "version": "1.1.6",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -867,7 +867,6 @@
             "version": "22.19.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -1165,7 +1164,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1345,7 +1343,6 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -1512,7 +1509,6 @@
         },
         "node_modules/zod": {
             "version": "4.1.8",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,25 @@ export const TodoReminderConfigSchema = z.object({
         ),
 
     /**
+     * Message format used instead of messageFormat when one of the pending
+     * todos already has status "in_progress" - i.e. the model was mid-task,
+     * not idle-and-stuck. messageFormat's default wording ("continue on the
+     * next pending task") is wrong in this case: it reads as an instruction
+     * to move on, when the correct instruction is to finish the task
+     * already underway. Supports the same interpolations as messageFormat,
+     * plus {current_task} (the in_progress todo's content).
+     * @default "You have an in-progress task: \"{current_task}\".\nContinue working on THIS task until it's done - do not skip ahead to a different one or restart it. Mark it complete when finished.\n\nStatus: {completed}/{total} completed, {remaining} remaining."
+     */
+    inProgressMessageFormat: z
+        .string()
+        .optional()
+        .default(
+            "You have an in-progress task: \"{current_task}\".\n" +
+            "Continue working on THIS task until it's done - do not skip ahead to a different one or restart it. Mark it complete when finished.\n\n" +
+            "Status: {completed}/{total} completed, {remaining} remaining."
+        ),
+
+    /**
      * Whether to show toast notifications (only if TUI supports it).
      * @default true
      */
@@ -75,6 +94,10 @@ const DEFAULT_CONFIG: Required<TodoReminderConfig> = {
     messageFormat:
         "Incomplete tasks remain in your todo list.\n" +
         "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
+        "Status: {completed}/{total} completed, {remaining} remaining.",
+    inProgressMessageFormat:
+        "You have an in-progress task: \"{current_task}\".\n" +
+        "Continue working on THIS task until it's done - do not skip ahead to a different one or restart it. Mark it complete when finished.\n\n" +
         "Status: {completed}/{total} completed, {remaining} remaining.",
     useToasts: true,
     syntheticPrompt: false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,13 +35,15 @@ export const TodoReminderConfigSchema = z.object({
     /**
      * Custom message format for the reminder prompt.
      * Supports interpolation: {total}, {completed}, {pending}, {remaining}
-     * @default "Incomplete tasks remain in your todo list.\nContinue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\nStatus: {completed}/{total} completed, {remaining} remaining."
+     * @default "Incomplete tasks remain in your todo list.\nIf any are already done, call todowrite to mark them complete/cancelled first.\nKeep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\nContinue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\nStatus: {completed}/{total} completed, {remaining} remaining."
      */
     messageFormat: z
         .string()
         .optional()
         .default(
             "Incomplete tasks remain in your todo list.\n" +
+            "If any are already done, call todowrite to mark them complete/cancelled first.\n" +
+            "Keep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\n" +
             "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
             "Status: {completed}/{total} completed, {remaining} remaining."
         ),
@@ -54,14 +56,16 @@ export const TodoReminderConfigSchema = z.object({
      * to move on, when the correct instruction is to finish the task
      * already underway. Supports the same interpolations as messageFormat,
      * plus {current_task} (the in_progress todo's content).
-     * @default "You have an in-progress task: \"{current_task}\".\nContinue working on THIS task until it's done - do not skip ahead to a different one or restart it. Mark it complete when finished.\n\nStatus: {completed}/{total} completed, {remaining} remaining."
+     * @default "You have an in-progress task: \"{current_task}\".\nIf it's already done, call todowrite to mark it complete first - otherwise continue working on THIS task until it's done; do not skip ahead to a different one or restart it. Keep todo statuses current going forward, not only when reminded. Mark it complete when finished.\n\nStatus: {completed}/{total} completed, {remaining} remaining."
      */
     inProgressMessageFormat: z
         .string()
         .optional()
         .default(
             "You have an in-progress task: \"{current_task}\".\n" +
-            "Continue working on THIS task until it's done - do not skip ahead to a different one or restart it. Mark it complete when finished.\n\n" +
+            "If it's already done, call todowrite to mark it complete first - otherwise " +
+            "continue working on THIS task until it's done; do not skip ahead to a different one or restart it. " +
+            "Keep todo statuses current going forward, not only when reminded. Mark it complete when finished.\n\n" +
             "Status: {completed}/{total} completed, {remaining} remaining."
         ),
 
@@ -70,6 +74,24 @@ export const TodoReminderConfigSchema = z.object({
      * @default true
      */
     useToasts: z.boolean().optional().default(true),
+
+    /**
+     * Whether TodoWrite calls are guarded against silently dropping
+     * unfinished todos. opencode's todowrite tool fully replaces the
+     * session's todo list on every call (delete-then-insert, verified in
+     * opencode's session/todo.ts) - there is no merge, and Todo has no
+     * stable id (verified in packages/schema/src/session-todo.ts: only
+     * content/status/priority), so anything the model forgets to
+     * re-include just disappears. When true, any todo the model didn't
+     * mention in a new TodoWrite call, and whose prior status was
+     * "pending" or "in_progress" (matched by exact content string - the
+     * only identity available), is appended back before the call reaches
+     * opencode. This does not let the model send a partial list on
+     * purpose (its tool description still says "the updated todo list"),
+     * it only stops accidental loss-by-omission.
+     * @default true
+     */
+    preserveUnfinishedTodos: z.boolean().optional().default(true),
 
     /**
      * Whether the injected prompt is synthetic (hidden from user)
@@ -93,13 +115,18 @@ const DEFAULT_CONFIG: Required<TodoReminderConfig> = {
     idleDelayMs: 500,
     messageFormat:
         "Incomplete tasks remain in your todo list.\n" +
+        "If any are already done, call todowrite to mark them complete/cancelled first.\n" +
+            "Keep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\n" +
         "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
         "Status: {completed}/{total} completed, {remaining} remaining.",
     inProgressMessageFormat:
         "You have an in-progress task: \"{current_task}\".\n" +
-        "Continue working on THIS task until it's done - do not skip ahead to a different one or restart it. Mark it complete when finished.\n\n" +
+        "If it's already done, call todowrite to mark it complete first - otherwise " +
+            "continue working on THIS task until it's done; do not skip ahead to a different one or restart it. " +
+        "Keep todo statuses current going forward, not only when reminded. Mark it complete when finished.\n\n" +
         "Status: {completed}/{total} completed, {remaining} remaining.",
     useToasts: true,
+    preserveUnfinishedTodos: true,
     syntheticPrompt: false,
     debug: false,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,7 @@ export const TodoReminderConfigSchema = z.object({
     /**
      * Custom message format for the reminder prompt.
      * Supports interpolation: {total}, {completed}, {pending}, {remaining}
-     * @default "Incomplete tasks remain in your todo list.\nIf any are already done, call todowrite to mark them complete/cancelled first.\nKeep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\nContinue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\nStatus: {completed}/{total} completed, {remaining} remaining."
+     * @default "Incomplete tasks remain in your todo list.\nIf any are already done, call todowrite to mark them complete/cancelled first.\nKeep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\nContinue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\nStatus: {completed}/{total} completed, {remaining} remaining.{orphan_table}"
      */
     messageFormat: z
         .string()
@@ -45,7 +45,7 @@ export const TodoReminderConfigSchema = z.object({
             "If any are already done, call todowrite to mark them complete/cancelled first.\n" +
             "Keep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\n" +
             "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
-            "Status: {completed}/{total} completed, {remaining} remaining."
+            "Status: {completed}/{total} completed, {remaining} remaining.{orphan_table}"
         ),
 
     /**
@@ -56,7 +56,7 @@ export const TodoReminderConfigSchema = z.object({
      * to move on, when the correct instruction is to finish the task
      * already underway. Supports the same interpolations as messageFormat,
      * plus {current_task} (the in_progress todo's content).
-     * @default "You have an in-progress task: \"{current_task}\".\nIf it's already done, call todowrite to mark it complete first - otherwise continue working on THIS task until it's done; do not skip ahead to a different one or restart it. Keep todo statuses current going forward, not only when reminded. Mark it complete when finished.\n\nStatus: {completed}/{total} completed, {remaining} remaining."
+     * @default "You have an in-progress task: \"{current_task}\".\nIf it's already done, call todowrite to mark it complete first - otherwise continue working on THIS task until it's done; do not skip ahead to a different one or restart it. Keep todo statuses current going forward, not only when reminded. Mark it complete when finished.\n\nStatus: {completed}/{total} completed, {remaining} remaining.{orphan_table}"
      */
     inProgressMessageFormat: z
         .string()
@@ -66,7 +66,7 @@ export const TodoReminderConfigSchema = z.object({
             "If it's already done, call todowrite to mark it complete first - otherwise " +
             "continue working on THIS task until it's done; do not skip ahead to a different one or restart it. " +
             "Keep todo statuses current going forward, not only when reminded. Mark it complete when finished.\n\n" +
-            "Status: {completed}/{total} completed, {remaining} remaining."
+            "Status: {completed}/{total} completed, {remaining} remaining.{orphan_table}"
         ),
 
     /**
@@ -94,6 +94,34 @@ export const TodoReminderConfigSchema = z.object({
     preserveUnfinishedTodos: z.boolean().optional().default(true),
 
     /**
+     * Whether to check for incomplete todos left behind in OTHER sessions
+     * in this project when the CURRENT session has none of its own.
+     * Session IDs change on every new/resumed/compacted session, and
+     * opencode's todo table is keyed by session_id with no cross-session
+     * carryover (verified: session table has project_id/parent_id, but
+     * SessionTodo has no linkage of its own) - so a session's incomplete
+     * todos, once that session ends, just sit in the DB forever unless
+     * something specifically goes looking across sessions. Off by default:
+     * this does extra API calls (session.list + one todo fetch per
+     * candidate session) that the other fixes in this plugin don't need,
+     * and surfaces information about possibly-abandoned/no-longer-relevant
+     * old work, which can be noise as easily as it can be useful. When
+     * enabled, this only shows a toast (does not inject anything into the
+     * model's context) - old sessions' tasks are not this session's plan,
+     * and should not be silently presented to the model as if they were.
+     * @default false
+     */
+    warnOrphanedTodos: z.boolean().optional().default(false),
+
+    /**
+     * Upper bound on how many other sessions (most-recently-updated first)
+     * to check for orphaned todos when warnOrphanedTodos is enabled. Bounds
+     * API cost when a project has accumulated many past sessions.
+     * @default 20
+     */
+    orphanScanLimit: z.number().optional().default(20),
+
+    /**
      * Whether the injected prompt is synthetic (hidden from user)
      * @default false
      */
@@ -116,17 +144,19 @@ const DEFAULT_CONFIG: Required<TodoReminderConfig> = {
     messageFormat:
         "Incomplete tasks remain in your todo list.\n" +
         "If any are already done, call todowrite to mark them complete/cancelled first.\n" +
-            "Keep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\n" +
+        "Keep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\n" +
         "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
-        "Status: {completed}/{total} completed, {remaining} remaining.",
+        "Status: {completed}/{total} completed, {remaining} remaining.{orphan_table}",
     inProgressMessageFormat:
         "You have an in-progress task: \"{current_task}\".\n" +
         "If it's already done, call todowrite to mark it complete first - otherwise " +
             "continue working on THIS task until it's done; do not skip ahead to a different one or restart it. " +
         "Keep todo statuses current going forward, not only when reminded. Mark it complete when finished.\n\n" +
-        "Status: {completed}/{total} completed, {remaining} remaining.",
+        "Status: {completed}/{total} completed, {remaining} remaining.{orphan_table}",
     useToasts: true,
     preserveUnfinishedTodos: true,
+    warnOrphanedTodos: false,
+    orphanScanLimit: 20,
     syntheticPrompt: false,
     debug: false,
 };

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -25,13 +25,18 @@ function createConfig(
         idleDelayMs: 500,
         messageFormat:
             "Incomplete tasks remain in your todo list.\n" +
+            "If any are already done, call todowrite to mark them complete/cancelled first.\n" +
+            "Keep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\n" +
             "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
             "Status: {completed}/{total} completed, {remaining} remaining.",
         inProgressMessageFormat:
             "You have an in-progress task: \"{current_task}\".\n" +
-            "Continue working on THIS task until it's done - do not skip ahead to a different one or restart it. Mark it complete when finished.\n\n" +
+            "If it's already done, call todowrite to mark it complete first - otherwise " +
+            "continue working on THIS task until it's done; do not skip ahead to a different one or restart it. " +
+            "Keep todo statuses current going forward, not only when reminded. Mark it complete when finished.\n\n" +
             "Status: {completed}/{total} completed, {remaining} remaining.",
         useToasts: true,
+        preserveUnfinishedTodos: true,
         syntheticPrompt: false,
         debug: false,
         ...overrides,
@@ -945,7 +950,9 @@ describe("TodoReminderPlugin", () => {
                             type: "text",
                             text:
                                 "Incomplete tasks remain in your todo list.\n" +
-                                "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
+                                "If any are already done, call todowrite to mark them complete/cancelled first.\n" +
+            "Keep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\n" +
+            "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
                                 "Status: 0/5 completed, 5 remaining.",
                         },
                     ],
@@ -1206,6 +1213,120 @@ describe("TodoReminderPlugin", () => {
 
             // Should have called prompt (assistant finished)
             expect(mockClient.session.prompt).toHaveBeenCalled();
+        });
+    });
+
+    describe("todowrite merge-guard (preserveUnfinishedTodos)", () => {
+        it("should backfill a pending todo the model omitted from a new TodoWrite call", async () => {
+            const hooks = await createPlugin();
+
+            mockClient.session.todo.mockResolvedValue({
+                data: [
+                    createTodo({ content: "Task A", status: "in_progress" }),
+                    createTodo({ content: "Task B", status: "pending" }),
+                ],
+            });
+
+            const output = {
+                args: {
+                    todos: [
+                        { content: "Task A", status: "completed", priority: "medium" },
+                    ],
+                },
+            };
+
+            await hooks["tool.execute.before"]?.(
+                { tool: "todowrite", sessionID: "session-x", callID: "call-1" },
+                output,
+            );
+
+            expect(output.args.todos).toEqual([
+                { content: "Task A", status: "completed", priority: "medium" },
+                expect.objectContaining({ content: "Task B", status: "pending" }),
+            ]);
+        });
+
+        it("should not touch the call when nothing was dropped", async () => {
+            const hooks = await createPlugin();
+
+            mockClient.session.todo.mockResolvedValue({
+                data: [createTodo({ content: "Task A", status: "pending" })],
+            });
+
+            const originalTodos = [
+                { content: "Task A", status: "in_progress", priority: "medium" },
+            ];
+            const output = { args: { todos: originalTodos } };
+
+            await hooks["tool.execute.before"]?.(
+                { tool: "todowrite", sessionID: "session-x", callID: "call-1" },
+                output,
+            );
+
+            expect(output.args.todos).toBe(originalTodos);
+        });
+
+        it("should not backfill a dropped todo that was already completed/cancelled", async () => {
+            const hooks = await createPlugin();
+
+            mockClient.session.todo.mockResolvedValue({
+                data: [
+                    createTodo({ content: "Task A", status: "completed" }),
+                    createTodo({ content: "Task B", status: "pending" }),
+                ],
+            });
+
+            const output = {
+                args: {
+                    todos: [
+                        { content: "Task B", status: "in_progress", priority: "medium" },
+                    ],
+                },
+            };
+
+            await hooks["tool.execute.before"]?.(
+                { tool: "todowrite", sessionID: "session-x", callID: "call-1" },
+                output,
+            );
+
+            // "Task A" was already completed, so its omission is fine - not backfilled.
+            expect(output.args.todos).toEqual([
+                { content: "Task B", status: "in_progress", priority: "medium" },
+            ]);
+        });
+
+        it("should ignore tool calls other than todowrite", async () => {
+            const hooks = await createPlugin();
+
+            const output = { args: { path: "foo.ts" } };
+            await hooks["tool.execute.before"]?.(
+                { tool: "read", sessionID: "session-x", callID: "call-1" },
+                output,
+            );
+
+            expect(mockClient.session.todo).not.toHaveBeenCalled();
+            expect(output.args).toEqual({ path: "foo.ts" });
+        });
+
+        it("should do nothing when preserveUnfinishedTodos is disabled", async () => {
+            mockConfig = createConfig({ preserveUnfinishedTodos: false });
+            const hooks = await createPlugin();
+
+            const output = {
+                args: {
+                    todos: [{ content: "Task A", status: "completed", priority: "medium" }],
+                },
+            };
+
+            await hooks["tool.execute.before"]?.(
+                { tool: "todowrite", sessionID: "session-x", callID: "call-1" },
+                output,
+            );
+
+            expect(mockClient.session.todo).not.toHaveBeenCalled();
+            expect(output.args.todos).toEqual([
+                { content: "Task A", status: "completed", priority: "medium" },
+            ]);
         });
     });
 

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -27,6 +27,10 @@ function createConfig(
             "Incomplete tasks remain in your todo list.\n" +
             "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
             "Status: {completed}/{total} completed, {remaining} remaining.",
+        inProgressMessageFormat:
+            "You have an in-progress task: \"{current_task}\".\n" +
+            "Continue working on THIS task until it's done - do not skip ahead to a different one or restart it. Mark it complete when finished.\n\n" +
+            "Status: {completed}/{total} completed, {remaining} remaining.",
         useToasts: true,
         syntheticPrompt: false,
         debug: false,
@@ -703,6 +707,85 @@ describe("TodoReminderPlugin", () => {
                     }),
                 }),
             );
+        });
+
+        it("should use inProgressMessageFormat, naming the in-progress task, instead of messageFormat when a todo is already in_progress", async () => {
+            const hooks = await createPlugin();
+
+            const inProgressTodo = createTodo({
+                id: "task-2",
+                status: "in_progress",
+                content: "Write axiom_gate_context.py",
+            });
+
+            await hooks.event?.({
+                event: {
+                    type: "todo.updated",
+                    properties: {
+                        sessionID: "session-in-progress",
+                        todos: [
+                            createTodo({ id: "task-1", status: "completed" }),
+                            inProgressTodo,
+                            createTodo({ id: "task-3", status: "pending" }),
+                        ],
+                    },
+                } as any,
+            });
+
+            mockClient.session.todo.mockResolvedValue({
+                data: [
+                    createTodo({ id: "task-1", status: "completed" }),
+                    inProgressTodo,
+                    createTodo({ id: "task-3", status: "pending" }),
+                ],
+            });
+
+            await hooks.event?.({
+                event: {
+                    type: "session.idle",
+                    properties: { sessionID: "session-in-progress" },
+                } as any,
+            });
+
+            await vi.advanceTimersByTimeAsync(2000);
+
+            const call = (mockClient.session.prompt as any).mock.calls[0][0];
+            const sentText: string = call.body.parts[0].text;
+
+            expect(sentText).toContain("Write axiom_gate_context.py");
+            expect(sentText).not.toContain("next pending task");
+        });
+
+        it("should keep using messageFormat (\"next pending task\") when no todo is in_progress", async () => {
+            const hooks = await createPlugin();
+
+            await hooks.event?.({
+                event: {
+                    type: "todo.updated",
+                    properties: {
+                        sessionID: "session-all-pending",
+                        todos: [createTodo({ status: "pending" })],
+                    },
+                } as any,
+            });
+
+            mockClient.session.todo.mockResolvedValue({
+                data: [createTodo({ status: "pending" })],
+            });
+
+            await hooks.event?.({
+                event: {
+                    type: "session.idle",
+                    properties: { sessionID: "session-all-pending" },
+                } as any,
+            });
+
+            await vi.advanceTimersByTimeAsync(2000);
+
+            const call = (mockClient.session.prompt as any).mock.calls[0][0];
+            const sentText: string = call.body.parts[0].text;
+
+            expect(sentText).toContain("next pending task");
         });
     });
 

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -28,15 +28,17 @@ function createConfig(
             "If any are already done, call todowrite to mark them complete/cancelled first.\n" +
             "Keep todo statuses current going forward - update each one via todowrite as soon as it is finished, not only when reminded.\n" +
             "Continue working on the next pending task now; do not ask for permission; mark tasks complete when done.\n\n" +
-            "Status: {completed}/{total} completed, {remaining} remaining.",
+            "Status: {completed}/{total} completed, {remaining} remaining.{orphan_table}",
         inProgressMessageFormat:
             "You have an in-progress task: \"{current_task}\".\n" +
             "If it's already done, call todowrite to mark it complete first - otherwise " +
             "continue working on THIS task until it's done; do not skip ahead to a different one or restart it. " +
             "Keep todo statuses current going forward, not only when reminded. Mark it complete when finished.\n\n" +
-            "Status: {completed}/{total} completed, {remaining} remaining.",
+            "Status: {completed}/{total} completed, {remaining} remaining.{orphan_table}",
         useToasts: true,
         preserveUnfinishedTodos: true,
+        warnOrphanedTodos: false,
+        orphanScanLimit: 20,
         syntheticPrompt: false,
         debug: false,
         ...overrides,
@@ -57,6 +59,7 @@ describe("TodoReminderPlugin", () => {
             todo: ReturnType<typeof vi.fn>;
             prompt: ReturnType<typeof vi.fn>;
             messages: ReturnType<typeof vi.fn>;
+            list: ReturnType<typeof vi.fn>;
         };
         tui: {
             showToast: ReturnType<typeof vi.fn>;
@@ -73,6 +76,7 @@ describe("TodoReminderPlugin", () => {
                 todo: vi.fn(),
                 prompt: vi.fn(),
                 messages: vi.fn().mockResolvedValue({ data: [] }),
+                list: vi.fn().mockResolvedValue({ data: [] }),
             },
             tui: {
                 showToast: vi.fn(),
@@ -1327,6 +1331,123 @@ describe("TodoReminderPlugin", () => {
             expect(output.args.todos).toEqual([
                 { content: "Task A", status: "completed", priority: "medium" },
             ]);
+        });
+    });
+
+    describe("orphaned todos across sessions (warnOrphanedTodos)", () => {
+        it("should append an orphan table to the periodic reminder when another session has pending todos", async () => {
+            mockConfig = createConfig({ warnOrphanedTodos: true });
+            const hooks = await createPlugin();
+
+            (mockClient.session.todo as any).mockImplementation(async (opts: any) => {
+                const id = opts?.path?.id;
+                if (id === "session-current") {
+                    return { data: [createTodo({ content: "Current task", status: "pending" })] };
+                }
+                if (id === "session-old-1") {
+                    return { data: [createTodo({ content: "Old unfinished task", status: "pending" })] };
+                }
+                return { data: [] };
+            });
+
+            (mockClient.session.list as any).mockResolvedValue({
+                data: [
+                    { id: "session-current", title: "Current", time: { updated: 2000 } },
+                    { id: "session-old-1", title: "Old Session", time: { updated: 1000 } },
+                ],
+            });
+
+            await hooks.event?.({
+                event: {
+                    type: "session.idle",
+                    properties: { sessionID: "session-current" },
+                } as any,
+            });
+
+            await vi.advanceTimersByTimeAsync(2000);
+
+            const call = (mockClient.session.prompt as any).mock.calls[0][0];
+            const sentText: string = call.body.parts[0].text;
+
+            expect(sentText).toContain("Orphaned todos in other sessions");
+            expect(sentText).toContain("session-old-1 - 1 open");
+        });
+
+        it("should not call session.list at all when warnOrphanedTodos is disabled", async () => {
+            mockConfig = createConfig({ warnOrphanedTodos: false });
+            const hooks = await createPlugin();
+
+            mockClient.session.todo.mockResolvedValue({
+                data: [createTodo({ status: "pending" })],
+            });
+
+            await hooks.event?.({
+                event: {
+                    type: "session.idle",
+                    properties: { sessionID: "session-current" },
+                } as any,
+            });
+
+            await vi.advanceTimersByTimeAsync(2000);
+
+            expect(mockClient.session.list).not.toHaveBeenCalled();
+
+            const call = (mockClient.session.prompt as any).mock.calls[0][0];
+            const sentText: string = call.body.parts[0].text;
+            expect(sentText).not.toContain("Orphaned todos");
+        });
+
+        it("should not append anything when no other session has pending todos", async () => {
+            mockConfig = createConfig({ warnOrphanedTodos: true });
+            const hooks = await createPlugin();
+
+            (mockClient.session.todo as any).mockImplementation(async (opts: any) => {
+                const id = opts?.path?.id;
+                if (id === "session-current") {
+                    return { data: [createTodo({ content: "Current task", status: "pending" })] };
+                }
+                return { data: [] };
+            });
+            (mockClient.session.list as any).mockResolvedValue({
+                data: [{ id: "session-current", title: "Current", time: { updated: 1000 } }],
+            });
+
+            await hooks.event?.({
+                event: {
+                    type: "session.idle",
+                    properties: { sessionID: "session-current" },
+                } as any,
+            });
+
+            await vi.advanceTimersByTimeAsync(2000);
+
+            const call = (mockClient.session.prompt as any).mock.calls[0][0];
+            const sentText: string = call.body.parts[0].text;
+            expect(sentText).not.toContain("Orphaned todos");
+        });
+
+        it("should only scan once per session, reusing the cached table across repeated reminders", async () => {
+            mockConfig = createConfig({ warnOrphanedTodos: true, idleDelayMs: 1000 });
+            const hooks = await createPlugin();
+
+            mockClient.session.todo.mockResolvedValue({
+                data: [createTodo({ content: "Still pending", status: "pending" })],
+            });
+            (mockClient.session.list as any).mockResolvedValue({ data: [] });
+
+            // Same unchanged todo snapshot -> reminder fires again on the
+            // next idle without a "change detected" reset in between.
+            for (let i = 0; i < 3; i++) {
+                await hooks.event?.({
+                    event: {
+                        type: "session.idle",
+                        properties: { sessionID: "session-current" },
+                    } as any,
+                });
+                await vi.advanceTimersByTimeAsync(1000);
+            }
+
+            expect(mockClient.session.list).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -32,7 +32,8 @@ function createReminderMessagePattern(template: string): RegExp {
         .replace(/\\\{total\\\}/g, "\\d+")
         .replace(/\\\{completed\\\}/g, "\\d+")
         .replace(/\\\{pending\\\}/g, "\\d+")
-        .replace(/\\\{remaining\\\}/g, "\\d+");
+        .replace(/\\\{remaining\\\}/g, "\\d+")
+        .replace(/\\\{current_task\\\}/g, "[\\s\\S]*");
 
     return new RegExp(`^${withPlaceholders}$`);
 }
@@ -209,7 +210,10 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
         }
     }
 
-    const reminderMessagePattern = createReminderMessagePattern(config.messageFormat);
+    const reminderMessagePatterns = [
+        createReminderMessagePattern(config.messageFormat),
+        createReminderMessagePattern(config.inProgressMessageFormat),
+    ];
 
     installPromptGuard(client, (options: unknown): boolean => {
         const payload = getPromptPayload(options);
@@ -221,7 +225,7 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
             return false;
         }
 
-        if (!reminderMessagePattern.test(payload.text)) {
+        if (!reminderMessagePatterns.some((pattern) => pattern.test(payload.text))) {
             return false;
         }
 
@@ -332,15 +336,24 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
             return;
         }
 
-        // Build the reminder message using the configured format
+        // Build the reminder message using the configured format.
+        // A todo already marked in_progress means the model was mid-task,
+        // not idle-and-stuck - messageFormat's "next pending task" wording
+        // is wrong there (reads as "move on" when it should be "finish
+        // this one"), so use inProgressMessageFormat instead.
         const completed = todos.filter(
             (t) => t.status === "completed" || t.status === "cancelled",
         ).length;
-        const message = config.messageFormat
+        const inProgressTodo = pending.find((t) => t.status === "in_progress");
+        const template = inProgressTodo
+            ? config.inProgressMessageFormat
+            : config.messageFormat;
+        const message = template
             .replace(/\{total\}/g, String(todos.length))
             .replace(/\{completed\}/g, String(completed))
             .replace(/\{pending\}/g, String(pending.length))
-            .replace(/\{remaining\}/g, String(pending.length));
+            .replace(/\{remaining\}/g, String(pending.length))
+            .replace(/\{current_task\}/g, inProgressTodo?.content ?? "");
 
         // Send it!
         log("SENDING PROMPT", { message });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -420,8 +420,61 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
         timers.set(sessionID, t);
     }
 
+    // Guard against opencode's todowrite tool silently dropping unfinished
+    // todos. Verified in opencode source: SessionTodo.Service.update does a
+    // full delete-then-insert of whatever `todos` array it's given - no
+    // merge, no diffing against the prior list. Todo has no stable id
+    // (packages/schema/src/session-todo.ts: content/status/priority only),
+    // so the only identity available for matching across calls is the
+    // content string. If the model's new TodoWrite call omits a todo that
+    // was pending/in_progress, that todo is gone with no warning. This
+    // backfills it before the call reaches opencode - it does NOT let the
+    // model send an intentionally partial list (its tool description still
+    // says "the updated todo list"), it only stops accidental loss.
+    async function guardTodoWrite(
+        input: { tool: string; sessionID: string; callID: string },
+        output: { args: any },
+    ): Promise<void> {
+        if (!config.preserveUnfinishedTodos) return;
+        if (input.tool !== "todowrite") return;
+
+        const proposed = output.args?.todos;
+        if (!Array.isArray(proposed)) return;
+
+        let current: Todo[];
+        try {
+            const resp = await client.session.todo({ path: { id: input.sessionID } });
+            current = Array.isArray(resp.data) ? resp.data : [];
+        } catch (e) {
+            log("guardTodoWrite: failed to fetch current todos", String(e));
+            return;
+        }
+
+        const proposedContents = new Set(
+            proposed
+                .map((t) => (t && typeof t === "object" ? (t as { content?: unknown }).content : undefined))
+                .filter((c): c is string => typeof c === "string"),
+        );
+
+        const dropped = current.filter(
+            (t) =>
+                (t.status === "pending" || t.status === "in_progress") &&
+                !proposedContents.has(t.content),
+        );
+
+        if (dropped.length === 0) return;
+
+        log("guardTodoWrite: backfilling dropped unfinished todos", {
+            sessionID: input.sessionID,
+            dropped: dropped.map((t) => t.content),
+        });
+
+        output.args.todos = [...proposed, ...dropped];
+    }
+
     // Handle events
     return {
+        "tool.execute.before": guardTodoWrite,
         event: async ({ event }) => {
             // log("EVENT", event.type, event.properties);
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -120,6 +120,20 @@ function isMessageAbortedError(error: unknown): boolean {
     return maybeError.name === "MessageAbortedError";
 }
 
+// True for ANY assistant-message error, not just user-initiated aborts.
+// opencode's processor.halt() sets assistantMessage.error identically for a
+// deny-rule tool-permission block (Effect.orDie -> defect -> halt, verified
+// in session/tools.ts + processor.ts:596-624) as it does for an escape-key
+// abort - both flip session status to idle via the same code path. Filtering
+// on MessageAbortedError alone let that error case fall through as ordinary
+// idle, unpaused. NOTE: this does not address the separate, likely more
+// common case of the reminder firing on a normal idle mid-task with no error
+// at all - that is the plugin's underlying idle-triggers-reminder design and
+// is out of scope here.
+function hasAssistantMessageError(error: unknown): boolean {
+    return !!error && typeof error === "object";
+}
+
 function setupDebug(directory: string | undefined, enabled: boolean): void {
     debugEnabled = enabled;
     if (enabled && directory) {
@@ -159,7 +173,7 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
     const injectCounts = new Map<string, number>();
     const lastSnapshots = new Map<string, string>();
     const seenUserMsgs = new Map<string, string>(); // sessionID -> last user message ID
-    const abortedSessions = new Set<string>(); // sessions aborted by user (escape key)
+    const abortedSessions = new Set<string>(); // sessions paused: user abort OR any assistant-message error (e.g. permission denial)
 
     async function showInterruptionPausedToast(): Promise<void> {
         if (!config.useToasts) {
@@ -172,7 +186,7 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
                 body: {
                     title: "TODO Reminder Paused",
                     message:
-                        "No reminder will be fired because you interrupted the last response. Send a new message to resume reminders.",
+                        "No reminder will be fired because the last response was interrupted or ended in an error. Send a new message to resume reminders.",
                     variant: "info",
                 },
             });
@@ -425,9 +439,12 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
 
                 if (
                     info.role === "assistant" &&
-                    isMessageAbortedError(info.error)
+                    hasAssistantMessageError(info.error)
                 ) {
-                    log("ASSISTANT MESSAGE ABORTED", { sessionID: info.sessionID });
+                    log("ASSISTANT MESSAGE ERRORED", {
+                        sessionID: info.sessionID,
+                        errorName: (info.error as { name?: unknown })?.name,
+                    });
                     await pauseSessionAfterAbort(info.sessionID, "message-updated");
                     return;
                 }
@@ -447,12 +464,15 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
             }
 
             if (event.type === "session.error") {
-                // Check if this is a user abort (escape key pressed)
+                // Any session-level error (user abort, permission denial,
+                // provider error, etc.) halts the turn and flips status to
+                // idle via the same opencode code path - pause reminders for
+                // all of them, not just escape-key aborts.
                 const { sessionID, error } = event.properties as {
                     sessionID?: string;
                     error?: { name?: string };
                 };
-                if (sessionID && isMessageAbortedError(error)) {
+                if (sessionID && hasAssistantMessageError(error)) {
                     await pauseSessionAfterAbort(sessionID, "session-error");
                 }
             }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -33,7 +33,8 @@ function createReminderMessagePattern(template: string): RegExp {
         .replace(/\\\{completed\\\}/g, "\\d+")
         .replace(/\\\{pending\\\}/g, "\\d+")
         .replace(/\\\{remaining\\\}/g, "\\d+")
-        .replace(/\\\{current_task\\\}/g, "[\\s\\S]*");
+        .replace(/\\\{current_task\\\}/g, "[\\s\\S]*")
+        .replace(/\\\{orphan_table\\\}/g, "[\\s\\S]*");
 
     return new RegExp(`^${withPlaceholders}$`);
 }
@@ -175,6 +176,7 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
     const lastSnapshots = new Map<string, string>();
     const seenUserMsgs = new Map<string, string>(); // sessionID -> last user message ID
     const abortedSessions = new Set<string>(); // sessions paused: user abort OR any assistant-message error (e.g. permission denial)
+    const orphanTableCache = new Map<string, string>(); // sessionID -> cached {orphan_table} text, scanned once per session lifetime
 
     async function showInterruptionPausedToast(): Promise<void> {
         if (!config.useToasts) {
@@ -254,6 +256,70 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
     }
 
     // The main inject function - runs when session is idle
+    // Session IDs change on every new/resumed/compacted session, and
+    // opencode's todo table has no cross-session linkage of its own -
+    // once a session ends, its incomplete todos just sit in the DB
+    // forever unless something specifically goes looking. Rather than a
+    // separate toast/notification path, this is folded directly into the
+    // existing periodic reminder text via {orphan_table} - scanned once
+    // per session lifetime (cached, not re-scanned on every reminder),
+    // and only ever appended to a message this session was already
+    // going to receive. Never sent as its own standalone message -
+    // another session's leftover plan is not this session's plan.
+    async function getOrphanedTodoTable(sessionID: string): Promise<string> {
+        if (!config.warnOrphanedTodos) return "";
+        if (orphanTableCache.has(sessionID)) return orphanTableCache.get(sessionID) ?? "";
+
+        let sessions: Array<{ id: string; title: string; time: { updated: number } }>;
+        try {
+            const resp = await client.session.list({ query: { directory } });
+            sessions = Array.isArray(resp.data) ? (resp.data as typeof sessions) : [];
+        } catch (e) {
+            log("getOrphanedTodoTable: failed to list sessions", String(e));
+            return "";
+        }
+
+        const candidates = sessions
+            .filter((s) => s.id !== sessionID)
+            .sort((a, b) => b.time.updated - a.time.updated)
+            .slice(0, config.orphanScanLimit);
+
+        const openCounts = new Map<string, number>();
+        for (const candidate of candidates) {
+            try {
+                const resp = await client.session.todo({ path: { id: candidate.id } });
+                const todos = Array.isArray(resp.data) ? resp.data : [];
+                const openCount = todos.filter(
+                    (t) => t.status === "pending" || t.status === "in_progress",
+                ).length;
+                if (openCount > 0) {
+                    openCounts.set(candidate.id, openCount);
+                }
+            } catch (e) {
+                log("getOrphanedTodoTable: failed to fetch todos for candidate", {
+                    sessionID: candidate.id,
+                    error: String(e),
+                });
+            }
+        }
+
+        let table = "";
+        if (openCounts.size > 0) {
+            const rows = [...openCounts.entries()]
+                .map(([id, count]) => `${id} - ${count} open`)
+                .join("\n");
+            table = `\n\nOrphaned todos in other sessions (never revisited):\n${rows}`;
+        }
+
+        orphanTableCache.set(sessionID, table);
+        log("getOrphanedTodoTable: scanned", {
+            sessionID,
+            checked: candidates.length,
+            sessionsWithOrphans: openCounts.size,
+        });
+        return table;
+    }
+
     async function inject(sessionID: string): Promise<void> {
         log(">>> INJECT", { sessionID });
 
@@ -287,7 +353,10 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
             statuses: todos.map((t) => t.status),
         });
 
-        // No pending todos = nothing to do
+        // No pending todos = nothing to do. Orphaned todos in OTHER
+        // sessions aren't checked here - they only ride along on a
+        // reminder this session was already going to send (below), never
+        // as a reason to send one on their own.
         if (pending.length === 0) {
             log("No pending todos, done");
             injectCounts.delete(sessionID);
@@ -348,12 +417,14 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
         const template = inProgressTodo
             ? config.inProgressMessageFormat
             : config.messageFormat;
+        const orphanTable = await getOrphanedTodoTable(sessionID);
         const message = template
             .replace(/\{total\}/g, String(todos.length))
             .replace(/\{completed\}/g, String(completed))
             .replace(/\{pending\}/g, String(pending.length))
             .replace(/\{remaining\}/g, String(pending.length))
-            .replace(/\{current_task\}/g, inProgressTodo?.content ?? "");
+            .replace(/\{current_task\}/g, inProgressTodo?.content ?? "")
+            .replace(/\{orphan_table\}/g, orphanTable);
 
         // Send it!
         log("SENDING PROMPT", { message });
@@ -551,6 +622,7 @@ export const TodoReminderPlugin: Plugin = async ({ client, directory }) => {
                 lastSnapshots.delete(info.id);
                 seenUserMsgs.delete(info.id);
                 abortedSessions.delete(info.id);
+                orphanTableCache.delete(info.id);
             }
         },
     };


### PR DESCRIPTION
4-commit fix series for the opencode-todo-reminder plugin:

- **Commit 1**: Treat any assistant-message error as a pause trigger (not just MessageAbortedError)
- **Commit 2**: Add inProgressMessageFormat so active tasks get 'finish this' not 'move to next'
- **Commit 3**: Add preserveUnfinishedTodos guard to prevent todowrite from dropping unfinished tasks
- **Commit 4**: Add warnOrphanedTodos to detect incomplete todos orphaned in other sessions

All 39 existing tests pass. Built and tested locally.